### PR TITLE
Implements std::error::Error for jq_rs::errors::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ jq-sys = "0.2.1"
 [dev-dependencies]
 criterion = "0.2"
 serde_json = "1.0"
+matches = "0.1.8"
 
 [package.metadata.docs.rs]
 features = ["bundled"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Breaking Changes
 - Adopted 2018 edition. The minimum supported rust version is now **1.32** ([#14]).
 - Output from jq programs now includes a trailing newline, just like the output
   from the `jq` binary ([#6]).
+- Added custom `Error` and `Result` types, returned from fallible
+  functions/methods in this crate ([#8]).
 
 ## v0.3.1 ([2019-06-04](https://github.com/onelson/json-query/compare/v0.3.0..v0.3.1 "diff"))
 
@@ -201,6 +203,7 @@ Initial release.
 [#3]: https://github.com/onelson/json-query/issues/3
 [#4]: https://github.com/onelson/json-query/issues/4
 [#6]: https://github.com/onelson/jq-rs/pull/6
+[#8]: https://github.com/onelson/jq-rs/pull/8
 [#10]: https://github.com/onelson/json-query/issues/10
 [#12]: https://github.com/onelson/jq-rs/issues/12
 [#14]: https://github.com/onelson/jq-rs/issues/14

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,12 +4,13 @@ extern crate jq_rs;
 
 use criterion::black_box;
 use criterion::Criterion;
+use jq_rs::{JqProgram, Result};
 
-fn run_one_off(prog: &str, input: &str) -> Result<String, String> {
+fn run_one_off(prog: &str, input: &str) -> Result<String> {
     jq_rs::run(prog, input)
 }
 
-fn run_pre_compiled(prog: &mut jq_rs::JqProgram, input: &str) -> Result<String, String> {
+fn run_pre_compiled(prog: &mut JqProgram, input: &str) -> Result<String> {
     prog.run(input)
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,53 @@
+use std::error;
+use std::ffi;
+use std::fmt;
+use std::result;
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    /// The jq program failed to compile.
+    InvalidProgram,
+    /// System errors are raised by the internal jq state machine. These can
+    /// indicate problems parsing input, or even failures while initializing
+    /// the state machine itself.
+    ///
+    /// `reason` will be feedback from jq about what went wrong, when available.
+    System { reason: Option<String> },
+    /// Errors encountered during conversion between CString/String or vice
+    /// versa.
+    ///
+    /// `err` will be the original error which lead to this.
+    StringConvert { err: Box<error::Error> },
+    /// Something bad happened, but it was unexpected.
+    Unknown,
+}
+
+impl From<ffi::NulError> for Error {
+    fn from(err: ffi::NulError) -> Self {
+        Error::StringConvert { err: Box::new(err) }
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Error::StringConvert { err: Box::new(err) }
+    }
+}
+
+const UNKNOWN: &'static str = "Unknown JQ Error";
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let detail: String = match self {
+            Error::InvalidProgram => "JQ Program failed to compile.".into(),
+            Error::System { reason } => reason.as_ref().cloned().unwrap_or_else(|| UNKNOWN.into()),
+            Error::StringConvert { err } => format!("Failed to convert string: `{}`", err),
+            Error::Unknown => UNKNOWN.into(),
+        };
+        write!(f, "{}", detail)
+    }
+}
+
+impl error::Error for Error {}


### PR DESCRIPTION
Going with a conservative approach for errors to start with. This diff
adds an impl for the stdlib Error trait, and ensures there are From
impls for any other error types which can surface through this lib.

This also provides a custom Result type, which is adopted throughout.

Added the `matches` crate as a dev dep to make the tests which look at
the error types easier to write.

Fixes #8 