### PR TITLE
Added `query` to the keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/onelson/jq-rs"
 homepage = "https://github.com/onelson/jq-rs"
 license = "Apache-2.0/MIT"
 categories = ["api-bindings"]
-keywords = ["json", "jq"]
+keywords = ["json", "jq", "query"]
 readme = "README.md"
 edition = "2018"
 


### PR DESCRIPTION
I added "query" to the keywords to help people find this on crates.io as there are a few similar crates that use `json` and `query`.