### PR TITLE
Impl std::error::Error + Send + 'static for errors::Error. Refs #21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ jq-sys = "0.2.*"
 criterion = "0.2"
 serde_json = "1.0"
 matches = "0.1.8"
+error-chain = "0.12.*"
 
 [package.metadata.docs.rs]
 features = ["bundled"]

--- a/README.md
+++ b/README.md
@@ -140,15 +140,14 @@ system's package manager.
 See the [jq-sys building docs][jq-sys-building] for details on how to share
 hints with the [jq-sys] crate on how to link.
 
-[jq]: https://github.com/stedolan/jq
-[serde_json]: https://github.com/serde-rs/json
-[jq-rs]: https://crates.io/crates/jq-rs
-[json-query]: https://crates.io/crates/json-query
-[jq-sys]: https://github.com/onelson/jq-sys
-[jq-sys-building]: https://github.com/onelson/jq-sys#building
-[jq-src]: https://github.com/onelson/jq-src
-
 # Changelog
+
+## Unreleased
+
+Additions
+
+- Implements `std::error::Error + Send + 'static` for `jq_rs::Error` to better
+  integrate with popular error handling crate [error-chain] and others ([#22]).
 
 ## v0.4.0 ([2019-07-06](https://github.com/onelson/json-query/compare/v0.3.1..v0.4.0 "diff"))
 
@@ -202,6 +201,15 @@ Breaking Changes:
 
 Initial release.
 
+[jq]: https://github.com/stedolan/jq
+[serde_json]: https://github.com/serde-rs/json
+[jq-rs]: https://crates.io/crates/jq-rs
+[json-query]: https://crates.io/crates/json-query
+[jq-sys]: https://github.com/onelson/jq-sys
+[jq-sys-building]: https://github.com/onelson/jq-sys#building
+[jq-src]: https://github.com/onelson/jq-src
+[error-chain]: https://crates.io/crates/error-chain
+
 [#1]: https://github.com/onelson/json-query/issues/1
 [#3]: https://github.com/onelson/json-query/issues/3
 [#4]: https://github.com/onelson/json-query/issues/4
@@ -210,3 +218,4 @@ Initial release.
 [#10]: https://github.com/onelson/json-query/issues/10
 [#12]: https://github.com/onelson/jq-rs/issues/12
 [#14]: https://github.com/onelson/jq-rs/issues/14
+[#22]: https://github.com/onelson/jq-rs/pull/22

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,10 +48,6 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&dyn error::Error> {
-        self.source()
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Error::StringConvert { err } => {

--- a/tests/error-chain-compat.rs
+++ b/tests/error-chain-compat.rs
@@ -1,0 +1,20 @@
+extern crate jq_rs;
+#[macro_use]
+extern crate error_chain;
+
+mod errors {
+    // Create the Error, ErrorKind, ResultExt, and Result types
+    error_chain! {}
+}
+
+use errors::*;
+
+#[test]
+fn test_error_chain_compat() {
+    assert_eq!(
+        jq_rs::run(".", "[[[{}}")
+            .chain_err(|| "custom error message")
+            .map_err(|e| format!("{}", e)),
+        Err("custom error message".to_string())
+    );
+}

--- a/tests/error-chain-compat.rs
+++ b/tests/error-chain-compat.rs
@@ -1,6 +1,7 @@
 extern crate jq_rs;
 #[macro_use]
 extern crate error_chain;
+use error_chain::ChainedError;
 
 mod errors {
     error_chain! {
@@ -10,10 +11,10 @@ mod errors {
     }
 }
 
-use self::errors::{Error, ErrorKind};
+use self::errors::{Error, ErrorKind, ResultExt};
 
 #[test]
-fn test_error_chain_compat() {
+fn test_match_errorkind() {
     match jq_rs::run(".", "[[[{}}").unwrap_err().into() {
         Error(ErrorKind::Jq(e), _s) => {
             // Proving that jq_rs::Error does in fact implement `std::error::Error`.
@@ -24,4 +25,17 @@ fn test_error_chain_compat() {
         }
         _ => unreachable!("error-chain should be converting."),
     }
+}
+
+#[test]
+fn test_chain_err() {
+    let chain = jq_rs::run(".", "[[[{}}")
+        .chain_err(|| "custom message")
+        .unwrap_err()
+        .display_chain()
+        .to_string();
+
+    // the chain is a multi-line string mentioning each error in the chain.
+    assert!(chain.contains("custom message"));
+    assert!(chain.contains("Parse error"))
 }


### PR DESCRIPTION
Basically just adding implementations for `Error + Send + 'static` for the crate's `Error` enum. Also includes a couple of small integration tests to ensure we maintain compat with error-chain in the releases to come.