### PR TITLE
chore: enable test in CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,5 +30,5 @@ jobs:
           export JQ_LIB_DIR=$(eval which jq)
       - name: Build workspace
         run: export JQ_LIB_DIR=$(eval which jq) && cargo build
-      # - name: Test workspace
-      #   run: export JQ_LIB_DIR=$(eval which jq) && cargo test
+      - name: Test workspace
+        run: export JQ_LIB_DIR=$(eval which jq) && cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            # n.b. libjq is pinned at 1.6 for now, with 1.7 support planned for the future (ref: #37)
+            apt-deps: libjq-dev=1.6-2.1ubuntu3 libonig-dev
+            jq-lib-dir: /usr/lib/x86_64-linux-gnu/
+            onig-lib-dir: /usr/lib/x86_64-linux-gnu/
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -19,16 +25,13 @@ jobs:
           toolchain: stable
           profile: minimal
       - uses: Swatinem/rust-cache@v2
-      - name: Install jq
-        uses: dcarbone/install-jq-action@v1.0.1
-        with:
-          version: 1.6
-      - name: 'Check jq'
-        run: |
-          which jq
-          jq --version
-          export JQ_LIB_DIR=$(eval which jq)
+      # XXX: libjq _appears to be_ already installed (and available via pkg-config?) on darwin.
+      - name: Install System Deps (Linux)
+        if: ${{ matrix.apt-deps }}
+        run: sudo apt install -y ${{ matrix.apt-deps }}
+
       - name: Build workspace
-        run: export JQ_LIB_DIR=$(eval which jq) && cargo build
+        run: JQ_LIB_DIR="${{ matrix.jq-lib-dir }}" ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}" cargo build
+
       - name: Test workspace
-        run: export JQ_LIB_DIR=$(eval which jq) && cargo test
+        run: JQ_LIB_DIR="${{ matrix.jq-lib-dir }}" ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}" cargo test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ mod test {
     #[test]
     fn compile_error() {
         let res = run(". aa12312me  dsaafsdfsd", "{\"name\": \"test\"}");
-        assert_matches!(res, Err(Error::InvalidProgram));
+        assert_matches!(res, Err(Error::InvalidProgram { .. }));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #34 (mostly, Windows is still todo).

This activates the test run portion of the CI workflow. Along the way:

- one neglected test which failed to build was repaired
- the workflow was revised to install `libjq` and `libonig` rather than just the `jq` binary

Notably odd, the jq and onig libs seem to be pre-installed (with pkg-config metadata no less?) on macOS. For Linux, these had to be installed explicitly and configured via env vars for the compilation to work.

The libjq version is pinned at 1.6 for now.