### PR TITLE
ci: fixup macOS build/test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
             apt-deps: libjq-dev=1.6-2.1ubuntu3 libonig-dev
             jq-lib-dir: /usr/lib/x86_64-linux-gnu/
             onig-lib-dir: /usr/lib/x86_64-linux-gnu/
+          - os: macos-latest
+            use-install-jq-action: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -25,13 +27,29 @@ jobs:
           toolchain: stable
           profile: minimal
       - uses: Swatinem/rust-cache@v2
-      # XXX: libjq _appears to be_ already installed (and available via pkg-config?) on darwin.
+
       - name: Install System Deps (Linux)
         if: ${{ matrix.apt-deps }}
         run: sudo apt install -y ${{ matrix.apt-deps }}
 
+      - name: Install jq (macOS)
+        uses: dcarbone/install-jq-action@v1.0.1
+        with:
+          version: 1.6
+        if: ${{ matrix.use-install-jq-action }}
+
       - name: Build workspace
-        run: JQ_LIB_DIR="${{ matrix.jq-lib-dir }}" ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}" cargo build
+        # FIXME: config for linking is a real mess - figure out something tidier now that both linux/macOS are green
+        run: |
+          [[ ! -z "${{ matrix.use-install-jq-action }}" ]] && export JQ_LIB_DIR="$(eval which jq)"
+          [[ ! -z "${{ matrix.jq-lib-dir }}" ]] && export JQ_LIB_DIR="${{ matrix.jq-lib-dir }}"
+          [[ ! -z "${{ matrix.onig-lib-dir }}" ]] && export ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}"
+          cargo build
 
       - name: Test workspace
-        run: JQ_LIB_DIR="${{ matrix.jq-lib-dir }}" ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}" cargo test
+        # FIXME: config for linking is a real mess - figure out something tidier now that both linux/macOS are green
+        run: |
+          [[ ! -z "${{ matrix.use-install-jq-action }}" ]] && export JQ_LIB_DIR="$(eval which jq)"
+          [[ ! -z "${{ matrix.jq-lib-dir }}" ]] && export JQ_LIB_DIR="${{ matrix.jq-lib-dir }}"
+          [[ ! -z "${{ matrix.onig-lib-dir }}" ]] && export ONIG_LIB_DIR="${{ matrix.onig-lib-dir }}"
+          cargo test


### PR DESCRIPTION
Helps with #31

So the deal is, it seems like the "install jq" github action provides libs for macOS, but not for Linux (or at least on Linux it wasn't clear where the `.so` files wound up if they _were provided_). 

At this point the system dep installation for Linux and macOS is quite different and clumsy, but the build is green so I guess we can improve from here over time. 