### PR TITLE
Add support for several jq options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,90 @@ let parsed: Vec<i64> = serde_json::from_str(&output).unwrap();
 
 assert_eq!(vec![2009, 2012, 2014, 2016, 2019], parsed);
 ```
+## Options
 
-Barely any of the options or flags available from the [jq] cli are exposed
-currently.
-Literally all that is provided is the ability to execute a _jq program_ on a blob
-of json.
-Please pardon my dust as I sort out the details.
+Jq has flags to alter the way in which data is input or output, some of these flags are supported.
+The supported flags are available throught the _advanced varients of the run functions.
+
+```rust
+use jq_rs;
+use serde_json::{self, json};
+
+let data = json!({ "title": "Coraline", "year": 2009 });
+let query = ".title";
+
+// program output as a raw string, without quotes
+let output = jq_rs::run_advanced(query, &data.to_string(), jq_rs::JqOptions::default().with_raw_output(true));
+
+let output_raw = jq_rs::run_advanced(query, &data.to_string());
+
+assert_eq!("\"Coraline\"", output);
+```
+
+### Raw input and raw output
+
+jq-rs supports the `-R, --raw-input` and `-r, --raw-output` flags through the following options:
+
+```rust
+use jq_rs;
+let options = jq_rs::JqOptions::default()
+    .with_raw_output(true)
+    .with_raw_input(true);
+```
+
+These are disabled by default.
+
+### Compact output
+
+jq-rs supports the `-c, --compact-output`, `--tabs` and `--indent n` flags through the following options:
+
+```rust
+use jq_rs;
+let compact = jq_rs::JqOptions::default()
+    .with_indentation(jq_rs::JqIndentation::Compact);
+
+let tabs = jq_rs::JqOptions::default()
+    .with_indentation(jq_rs::JqIndentation::Tabs);
+
+let spaces_2 = jq_rs::JqOptions::default()
+    .with_indentation(jq_rs::JqIndentation::Spaces(2));
+```
+
+Compact is the default for this option.
+
+### Sorting
+
+jq-rs supports the `-S, --sort-keys` flag using the following option:
+
+```rust
+use jq_rs;
+let sorted = jq_rs::JqOptions::default()
+    .with_sort_keys(true);
+```
+
+Sorting is disabled by default.
+
+### Colorization
+
+jq-rs supports the `-C, --color-output` and `-M, --monochrome-output` flags.
+jq-rs also supports custom colors, which are normally available through the `JQ_COLORS` environment variable.
+
+```rust
+use jq_rs;
+
+let monochrome = jq_rs::JqOptions::default()
+    .with_colorization(jq_rs::JqColorization::Monochrome);
+
+let colorize = jq_rs::JqOptions::default()
+    .with_colorization(jq_rs::JqColorization::Colorize),
+
+let all_blue = jq_rs::JqOptions::default()
+    .with_colorization(jq_rs::JqColorization::Custom(
+        "0;34:0;34:0;34:0;34:0;34:0;34:0;34:0;34",
+    ));
+```
+
+The default option is monochrome, refer to the [jq documentation](https://jqlang.github.io/jq/manual/#colors) for using custom colors.
 
 ## Linking to libjq
 

--- a/examples/simple-cli.rs
+++ b/examples/simple-cli.rs
@@ -6,7 +6,13 @@ fn main() {
 
     let program = args.next().expect("jq program");
     let input = args.next().expect("data input");
-    match jq_rs::run(&program, &input) {
+    match jq_rs::run_advanced(
+        &program,
+        &input,
+        jq_rs::JqOptions::default()
+            .with_colorization(jq_rs::JqColorization::Colorize)
+            .with_indentation(jq_rs::JqIndentation::Spaces(2)),
+    ) {
         Ok(s) => print!("{}", s), // The output will include a trailing newline
         Err(e) => eprintln!("{}", e),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod options;
 use std::ffi::CString;
 
 pub use errors::{Error, Result};
-use options::JqOptions;
+pub use options::JqOptions;
 
 /// Run a jq program on a blob of json data.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl JqProgram {
             return Ok("".into());
         }
         let input = CString::new(data)?;
-        self.jq.execute_advanced(input, options)
+        self.jq.execute_advanced(input, &options)
     }
 }
 
@@ -381,7 +381,9 @@ mod test {
         let res = run_advanced(
             r#"."#,
             r#"{"name":"john"}"#,
-            JqOptions::default().with_colorization(JqColorization::Custom("0;34:0;34:0;34:0;34:0;34:0;34:0;34:0;34")),
+            JqOptions::default().with_colorization(JqColorization::Custom(
+                "0;34:0;34:0;34:0;34:0;34:0;34:0;34:0;34",
+            )),
         );
         let expected = "\u{1b}[0;34m{\u{1b}[0m\u{1b}[0;34m\"name\"\u{1b}[0m\u{1b}[0;34m:\u{1b}[0m\u{1b}[0;34m\"john\"\u{1b}[0m\u{1b}[0;34m}\u{1b}[0m\n";
         assert_eq!(res.unwrap(), expected);
@@ -392,7 +394,9 @@ mod test {
         let res = run_advanced(
             r#"."#,
             r#"{"name":"john"}"#,
-            JqOptions::default().with_colorization(JqColorization::Custom("0;34:0;34:0;34:0;34:0;34:0;34:0;34:0;34")),
+            JqOptions::default().with_colorization(JqColorization::Custom(
+                "0;34:0;34:0;34:0;34:0;34:0;34:0;34:0;34",
+            )),
         );
         let expected = "\u{1b}[0;34m{\u{1b}[0m\u{1b}[0;34m\"name\"\u{1b}[0m\u{1b}[0;34m:\u{1b}[0m\u{1b}[0;34m\"john\"\u{1b}[0m\u{1b}[0;34m}\u{1b}[0m\n";
         assert_eq!(res.unwrap(), expected);
@@ -453,7 +457,20 @@ mod test {
             r#"{"c":"fourth","b":{"c":"third","a": "second"},"a":"first"}"#,
             JqOptions::default().with_sort_keys(true),
         );
-        let expected = "{\"a\":\"first\",\"b\":{\"a\":\"second\",\"c\":\"third\"},\"c\":\"fourth\"}\n";
+        let expected =
+            "{\"a\":\"first\",\"b\":{\"a\":\"second\",\"c\":\"third\"},\"c\":\"fourth\"}\n";
+        assert_eq!(res.unwrap(), expected);
+    }
+
+    #[test]
+    fn raw_input() {
+        let res = run_advanced(
+            r#"."#,
+            r#"{"name":"john"}"#,
+            JqOptions::default().with_raw_input(true),
+        );
+        let expected = r#""{\"name\":\"john\"}"
+"#;
         assert_eq!(res.unwrap(), expected);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod options;
 use std::ffi::CString;
 
 pub use errors::{Error, Result};
-pub use options::JqOptions;
+pub use options::{JqOptions, JqColorization, JqIndentation};
 
 /// Run a jq program on a blob of json data.
 ///

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,112 @@
+/// Struct containing options that can be passed to jq to customize input/output
+pub struct JqOptions<'a> {
+    pub raw_output: bool,
+    pub raw_input: bool,
+    pub slurp: bool,
+    pub sort_keys: bool,
+    pub colorization: JqColorization<'a>,
+    pub indentation: JqIndentation,
+}
+
+impl<'a> Default for JqOptions<'a> {
+    fn default() -> Self {
+        JqOptions {
+            raw_input: false, // TODO
+            raw_output: false,
+            slurp: false, // TODO
+            sort_keys: false, // TODO
+            indentation: JqIndentation::Compact,
+            colorization: JqColorization::Monochrome,
+        }
+    }
+}
+
+impl<'a> JqOptions<'a> {
+    pub fn with_raw_output(&self, raw_output: bool) -> Self {
+        JqOptions {
+            raw_output,
+            raw_input: self.raw_input,
+            slurp: self.slurp,
+            sort_keys: self.sort_keys,
+            colorization: self.colorization,
+            indentation: self.indentation,
+        }
+    }
+
+    pub fn with_raw_input(&self, raw_input: bool) -> Self {
+        JqOptions {
+            raw_output: self.raw_output,
+            raw_input,
+            slurp: self.slurp,
+            sort_keys: self.sort_keys,
+            colorization: self.colorization,
+            indentation: self.indentation,
+        }
+    }
+
+    pub fn with_slurp(&self, slurp: bool) -> Self {
+        JqOptions {
+            raw_output: self.raw_output,
+            raw_input: self.raw_input,
+            slurp,
+            sort_keys: self.sort_keys,
+            colorization: self.colorization,
+            indentation: self.indentation,
+        }
+    }
+
+    pub fn with_sort_keys(&self, sort_keys: bool) -> Self {
+        JqOptions {
+            raw_output: self.raw_output,
+            raw_input: self.raw_input,
+            slurp: self.slurp,
+            sort_keys,
+            colorization: self.colorization,
+            indentation: self.indentation,
+        }
+    }
+
+    pub fn with_colorization(&self, colorization: JqColorization<'a>) -> Self {
+        JqOptions {
+            raw_output: self.raw_output,
+            raw_input: self.raw_input,
+            slurp: self.slurp,
+            sort_keys: self.sort_keys,
+            colorization,
+            indentation: self.indentation,
+        }
+    }
+
+    pub fn with_indentation(&self, indentation: JqIndentation) -> Self {
+        JqOptions {
+            raw_output: self.raw_output,
+            raw_input: self.raw_input,
+            slurp: self.slurp,
+            sort_keys: self.sort_keys,
+            colorization: self.colorization,
+            indentation,
+        }
+    }
+}
+
+/// The indentation options for jq
+#[derive(Copy, Clone)]
+pub enum JqIndentation {
+    /// Don't indent, fully compact
+    Compact,
+    /// Use tabs for indentation
+    Tabs,
+    /// Use spaces for indentation
+    Spaces(i32),
+}
+
+/// The two possible colorization options
+#[derive(Copy, Clone)]
+pub enum JqColorization<'a> {
+    /// Apply custom colors
+    Custom(&'a str),
+    /// Apply full colorization
+    Colorize,
+    /// Don't apply colorization
+    Monochrome,
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -15,7 +15,7 @@ pub struct JqOptions<'a> {
 impl<'a> Default for JqOptions<'a> {
     fn default() -> Self {
         JqOptions {
-            raw_input: false, // TODO
+            raw_input: false,
             raw_output: false,
             sort_keys: false,
             indentation: JqIndentation::Compact,

--- a/src/options.rs
+++ b/src/options.rs
@@ -2,7 +2,6 @@
 pub struct JqOptions<'a> {
     pub raw_output: bool,
     pub raw_input: bool,
-    pub slurp: bool,
     pub sort_keys: bool,
     pub colorization: JqColorization<'a>,
     pub indentation: JqIndentation,
@@ -13,7 +12,6 @@ impl<'a> Default for JqOptions<'a> {
         JqOptions {
             raw_input: false, // TODO
             raw_output: false,
-            slurp: false, // TODO
             sort_keys: false, // TODO
             indentation: JqIndentation::Compact,
             colorization: JqColorization::Monochrome,
@@ -26,7 +24,6 @@ impl<'a> JqOptions<'a> {
         JqOptions {
             raw_output,
             raw_input: self.raw_input,
-            slurp: self.slurp,
             sort_keys: self.sort_keys,
             colorization: self.colorization,
             indentation: self.indentation,
@@ -37,18 +34,6 @@ impl<'a> JqOptions<'a> {
         JqOptions {
             raw_output: self.raw_output,
             raw_input,
-            slurp: self.slurp,
-            sort_keys: self.sort_keys,
-            colorization: self.colorization,
-            indentation: self.indentation,
-        }
-    }
-
-    pub fn with_slurp(&self, slurp: bool) -> Self {
-        JqOptions {
-            raw_output: self.raw_output,
-            raw_input: self.raw_input,
-            slurp,
             sort_keys: self.sort_keys,
             colorization: self.colorization,
             indentation: self.indentation,
@@ -59,7 +44,6 @@ impl<'a> JqOptions<'a> {
         JqOptions {
             raw_output: self.raw_output,
             raw_input: self.raw_input,
-            slurp: self.slurp,
             sort_keys,
             colorization: self.colorization,
             indentation: self.indentation,
@@ -70,7 +54,6 @@ impl<'a> JqOptions<'a> {
         JqOptions {
             raw_output: self.raw_output,
             raw_input: self.raw_input,
-            slurp: self.slurp,
             sort_keys: self.sort_keys,
             colorization,
             indentation: self.indentation,
@@ -81,7 +64,6 @@ impl<'a> JqOptions<'a> {
         JqOptions {
             raw_output: self.raw_output,
             raw_input: self.raw_input,
-            slurp: self.slurp,
             sort_keys: self.sort_keys,
             colorization: self.colorization,
             indentation,

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,9 +1,14 @@
 /// Struct containing options that can be passed to jq to customize input/output
 pub struct JqOptions<'a> {
+    /// Output raw strings instead of quoted and escaped 
     pub raw_output: bool,
+    /// Interpret each input as string instead of json
     pub raw_input: bool,
+    /// Order the keys
     pub sort_keys: bool,
+    /// Use colors for the output
     pub colorization: JqColorization<'a>,
+    /// Apply indentation for the output
     pub indentation: JqIndentation,
 }
 
@@ -12,7 +17,7 @@ impl<'a> Default for JqOptions<'a> {
         JqOptions {
             raw_input: false, // TODO
             raw_output: false,
-            sort_keys: false, // TODO
+            sort_keys: false,
             indentation: JqIndentation::Compact,
             colorization: JqColorization::Monochrome,
         }
@@ -20,6 +25,7 @@ impl<'a> Default for JqOptions<'a> {
 }
 
 impl<'a> JqOptions<'a> {
+    /// Output raw strings instead of quoted and escaped 
     pub fn with_raw_output(&self, raw_output: bool) -> Self {
         JqOptions {
             raw_output,
@@ -30,6 +36,7 @@ impl<'a> JqOptions<'a> {
         }
     }
 
+    /// Interpret each input as string instead of json
     pub fn with_raw_input(&self, raw_input: bool) -> Self {
         JqOptions {
             raw_output: self.raw_output,
@@ -40,6 +47,7 @@ impl<'a> JqOptions<'a> {
         }
     }
 
+    /// Order the keys
     pub fn with_sort_keys(&self, sort_keys: bool) -> Self {
         JqOptions {
             raw_output: self.raw_output,
@@ -50,6 +58,7 @@ impl<'a> JqOptions<'a> {
         }
     }
 
+    /// Use colors for the output
     pub fn with_colorization(&self, colorization: JqColorization<'a>) -> Self {
         JqOptions {
             raw_output: self.raw_output,
@@ -60,6 +69,7 @@ impl<'a> JqOptions<'a> {
         }
     }
 
+    /// Apply indentation for the output
     pub fn with_indentation(&self, indentation: JqIndentation) -> Self {
         JqOptions {
             raw_output: self.raw_output,


### PR DESCRIPTION
Options:
```
-R, --raw-input           read each line as string instead of JSON
-c, --compact-output      compact instead of pretty-printed output
-r, --raw-output          output strings without escapes and quotes
-S, --sort-keys           sort keys of each object on output
-C, --color-output        colorize JSON output
-M, --monochrome-output   disable colored output
--tab                 use tabs for indentation;
--indent n            use n spaces for indentation (max 7 spaces)
```

I also added support for custom colors as is normally available using the `JQ_COLORS ` environment variable.
https://jqlang.github.io/jq/manual/#colors

TODO: some code cleaning, and more documentation